### PR TITLE
fix: fix Input border on mobile devices

### DIFF
--- a/vite/Input/styles.module.css
+++ b/vite/Input/styles.module.css
@@ -1,7 +1,6 @@
 .input {
   padding: 0 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-right: none;
   border-radius: 5px;
   background-color: rgba(255, 255, 255, 0.1);
   display: flex;
@@ -18,12 +17,12 @@
     flex: 1;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    border-right: none;
   }
 }
 
 .input:focus {
-  border: 1px solid var(--button-border-color);
-  border-right: none;
+  border-color: var(--button-border-color);
   outline: none;
 }
 


### PR DESCRIPTION
Add border-right to input when is focused.
Before / After:

![Zrzut ekranu 2023-12-17 005739](https://github.com/remotion-dev/github-unwrapped-2023/assets/27455716/e0bf9473-ba76-41c5-b209-3a4a735f1362)
