### PR TITLE
fix: correct svg color and button styling on share to linkedin page

### DIFF
--- a/icons/CheckmarkIcon.tsx
+++ b/icons/CheckmarkIcon.tsx
@@ -1,4 +1,5 @@
 import type { SVGProps } from "react";
+import { PANE_TEXT_COLOR } from '../remotion/TopLanguages/Pane';
 export const CheckmarkIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -8,6 +9,7 @@ export const CheckmarkIcon = (props: SVGProps<SVGSVGElement>) => (
     stroke="currentColor"
     strokeWidth={0}
     viewBox="0 0 512 512"
+    color = {PANE_TEXT_COLOR}
     {...props}
   >
     <path

--- a/icons/CopyIcon.tsx
+++ b/icons/CopyIcon.tsx
@@ -1,4 +1,5 @@
 import type { SVGProps } from "react";
+import { PANE_TEXT_COLOR } from '../remotion/TopLanguages/Pane';
 export const CopyIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -7,6 +8,7 @@ export const CopyIcon = (props: SVGProps<SVGSVGElement>) => (
     fill="currentColor"
     stroke="currentColor"
     strokeWidth={0}
+    color = {PANE_TEXT_COLOR}
     viewBox="0 0 24 24"
     {...props}
   >

--- a/vite/VideoPage/Actions/SharingAction.tsx
+++ b/vite/VideoPage/Actions/SharingAction.tsx
@@ -65,6 +65,7 @@ export const SharingAction: React.FC<{
           fontWeight: "600",
           backgroundColor: "#D3CFE8",
           color: PANE_TEXT_COLOR,
+          padding: "0px 10px"
         }}
       >
         {props.icon && (


### PR DESCRIPTION
Fixes issue #220 

- Fixed the button UI issue with 10px left and right padding
- Fixed the SVG color issue with the `PANE_TEXT_COLOR` same as the text color